### PR TITLE
Set up React Native environment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['@react-native-community'],
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# React Native
+android/
+ios/
+.expo/
+*.iml
+.gradle/
+build/
+.DS_Store
+.env
+
+# Metro
+*.metro*
+
+# TypeScript
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # StepShowdown
+
+A fresh React Native project scaffolded with the latest tooling.
+
+## Getting Started
+
+1. Install dependencies
+   ```sh
+   npm install
+   ```
+2. Start the Metro bundler
+   ```sh
+   npm run start
+   ```
+3. Launch the app
+   - Android: `npm run android`
+   - iOS: `npm run ios`
+
+## Scripts
+
+- `npm run start` – start the Metro bundler.
+- `npm run android` – build and launch the Android app (requires Android SDK).
+- `npm run ios` – build and launch the iOS app (requires Xcode).
+- `npm run lint` – run ESLint.
+
+## Project Structure
+
+- `src/App.tsx` – the entry point for your React Native UI.
+- `index.js` – registers the app with the native runtime.
+- `tsconfig.json` – TypeScript configuration aligned with React Native defaults.
+- `metro.config.js` – Metro bundler configuration.
+- `babel.config.js` – Babel configuration using the React Native preset.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "StepShowdown",
+  "displayName": "Step Showdown"
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import {AppRegistry} from 'react-native';
+import App from './src/App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'react-native',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,5 @@
+const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+
+const config = {};
+
+module.exports = mergeConfig(getDefaultConfig(__dirname), config);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "stepshowdown",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.74.3"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@react-native-community/eslint-config": "^3.2.0",
+    "@react-native/metro-config": "^0.77.0",
+    "@tsconfig/react-native": "^2.0.5",
+    "@types/react": "^18.2.45",
+    "@types/react-native": "^0.74.4",
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "metro-react-native-babel-preset": "^0.77.0",
+    "react-test-renderer": "18.2.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {SafeAreaView, StatusBar, StyleSheet, Text, View} from 'react-native';
+
+function App(): React.JSX.Element {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar barStyle="dark-content" backgroundColor={styles.safeArea.backgroundColor} />
+      <View style={styles.container}>
+        <Text style={styles.title}>Welcome to Step Showdown</Text>
+        <Text style={styles.subtitle}>
+          This React Native project is ready for you to build with the latest tooling.
+        </Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#f0f4f8',
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    gap: 12,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#0f172a',
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#475569',
+    textAlign: 'center',
+  },
+});
+
+export default App;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/react-native/tsconfig.json",
+  "compilerOptions": {
+    "types": ["react", "react-native"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "**/*.tsx", "metro.config.js", "babel.config.js", "index.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- bootstrap a new React Native 0.74 project with TypeScript, Metro, Babel, and linting configuration
- add an entry App component and registration wiring for the native runtime
- document project scripts and structure in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6fe5676008326b0017d126d64eeb9